### PR TITLE
Proxy all absolute image URLs, even if they don't begin with http or https

### DIFF
--- a/camo.py
+++ b/camo.py
@@ -32,13 +32,13 @@ class CamoClient(object):
         doc = self._rewrite_image_urls(doc)
         # iterating over a node returns all the tags within that node
         # ..if there are none, return the original string
-        return b''.join(map(html.tostring, doc)).decode() or string
+        return ''.join(map(html.tostring, doc)) or string
 
 
 class Image(object):
     def __init__(self, url, key):
-        self.url = bytes(url, 'utf-8')
-        self.key = bytes(key, 'utf-8')
+        self.url = url
+        self.key = key
 
     @mproperty
     def path(self):
@@ -50,4 +50,4 @@ class Image(object):
 
     @mproperty
     def encoded_url(self):
-        return self.url.hex()
+        return self.url.encode("hex")

--- a/camo.py
+++ b/camo.py
@@ -1,6 +1,7 @@
 import hashlib
 import hmac
 import re
+import urlparse
 from memoize import mproperty
 from lxml import html
 
@@ -13,10 +14,14 @@ class CamoClient(object):
     def image_url(self, url):
         return self.server + Image(url, self.key).path
 
+    def _is_absolute(self, url):
+        parsed_url = urlparse.urlparse(url.strip())
+        return bool(parsed_url.netloc)
+
     def _rewrite_url(self, url):
         if url.startswith(self.server):
             return url
-        elif not any(map(url.startswith, ["http://", "https://"])):
+        elif not self._is_absolute(url):
             return url
         else:
             return self.image_url(url)

--- a/tests/camo_test.py
+++ b/tests/camo_test.py
@@ -25,9 +25,15 @@ class CamoClientTest(unittest.TestCase):
 
     def test_parses_html(self):
         client = CamoClient("https://fakecdn.org/", key="hello")
-        html = """<img src="http://example.net/images/hahafunny.jpg" /><img src="https://otherexample/moreserious.png" />"""
+        html = """<img src="http://example.net/images/hahafunny.jpg" /><img src="https://otherexample/moreserious.png" />"""\
+               """<img src="//example.net/no_http.jpg" /><img src=" http://example.net/leading_space.jpg" />"""\
+               """<img src=http://example.net/mising_quotes.jpg /><img src="ftp://example.net/ftp_image.jpg" />"""
         parsed = """<img src="https://fakecdn.org/735030fa488e1866b4302ac611c075d541a773e3/687474703a2f2f6578616d706c652e6e65742f696d616765732f6861686166756e6e792e6a7067">"""\
-                 """<img src="https://fakecdn.org/c81915f5756fad02cfae7d07e359624dae877667/68747470733a2f2f6f746865726578616d706c652f6d6f7265736572696f75732e706e67">"""
+                 """<img src="https://fakecdn.org/c81915f5756fad02cfae7d07e359624dae877667/68747470733a2f2f6f746865726578616d706c652f6d6f7265736572696f75732e706e67">"""\
+                 """<img src="https://fakecdn.org/1d5de168888358e62b7c2f850265c5bfb43e46c3/2f2f6578616d706c652e6e65742f6e6f5f687474702e6a7067">"""\
+                 """<img src="https://fakecdn.org/f4837f9cd17f391dd4c78e49f7b57934f6966f7c/20687474703a2f2f6578616d706c652e6e65742f6c656164696e675f73706163652e6a7067">"""\
+                 """<img src="https://fakecdn.org/d4ef06afe02debfdcbce1b1b078666e918732793/687474703a2f2f6578616d706c652e6e65742f6d6973696e675f71756f7465732e6a7067">"""\
+                 """<img src="https://fakecdn.org/46bb6a3963ac29bd9c1587f2f533dad926c82330/6674703a2f2f6578616d706c652e6e65742f6674705f696d6167652e6a7067">"""
         self.assertEqual(client.parse_html(html), parsed)
 
     def test_ignores_already_hosted(self):
@@ -38,6 +44,11 @@ class CamoClientTest(unittest.TestCase):
     def test_ignores_relative(self):
         client = CamoClient("https://fakecdn.org/", key="hello")
         html = """<p><img src="/images/hahafunny.jpg"></p>"""
+        self.assertEqual(client.parse_html(html), html)
+
+    def test_ignores_data_uri(self):
+        client = CamoClient("https://fakecdn.org/", key="hello")
+        html = """<p><img src="data:image/png;base64,iVBOR0t8XDY0bb"></p>"""
         self.assertEqual(client.parse_html(html), html)
 
     def test_unmarkedup_text(self):


### PR DESCRIPTION
The first commit is just reverting some python 3 compatibility changes that David made before realizing that the notebook server run on python 2 (we're only just now reverting because previously we were getting this library from PyPI and this fork was unused).  

The second commit is the bug fix, which makes us proxy some additional URL formats.  Previously this repo would only proxy URLs that began with http:// or https://, in an attempt to avoid proxying relative URLs and data URI src attributes.  This causes the following URLs to not be proxied, even though all browsers interpret them as absolute URLs
```
//www.example.com/image.jpg
 http://www.example.com/image.jpg (notice the leading space)
ftp://www.example.com/image.jpg
```

The case that prompted this fix was URLs beginning with "//" which is apparently called a "protocol relative URL" and it's a way for images to be loaded with the same protocol as the current page (http vs https).  It's described here https://www.paulirish.com/2010/the-protocol-relative-url/ and the original URI spec https://tools.ietf.org/html/rfc3986#section-3 shows that it's allowed.

The fact that whitespace characters are allowed before and after the URL is described in the HTML5 spec here: https://www.w3.org/TR/2014/REC-html5-20141028/infrastructure.html#valid-url-potentially-surrounded-by-spaces and I confirmed that this was the case in testing.

I got the strategy for determining whether a URL is absolute or relative from this StackOverflow post: https://stackoverflow.com/questions/8357098/how-can-i-check-if-a-url-is-absolute-using-python