### PR TITLE
Combined image_url and _rewrite_url into a single method.

### DIFF
--- a/camo.py
+++ b/camo.py
@@ -11,20 +11,17 @@ class CamoClient(object):
         self.key = key
 
     def image_url(self, url):
-        return self.server + Image(url, self.key).path
-
-    def _rewrite_url(self, url):
         # skip images that have already been proxied and
         # images with data URIs
         if url.startswith(self.server) or url.startswith("data:image/"):
             return url
         else:
-            return self.image_url(url)
+            return self.server + Image(url, self.key).path
 
     def _rewrite_image_urls(self, node):
         for img in node.xpath('.//img'):
             if img.get('src'):
-                img.set('src', self._rewrite_url(img.get('src')))
+                img.set('src', self.image_url(img.get('src')))
         return node
 
     def parse_html(self, string):

--- a/camo.py
+++ b/camo.py
@@ -13,7 +13,7 @@ class CamoClient(object):
     def image_url(self, url):
         # skip images that have already been proxied and
         # images with data URIs
-        if url.startswith(self.server) or url.startswith("data:image/"):
+        if url.startswith(self.server):
             return url
         else:
             return self.server + Image(url, self.key).path

--- a/tests/camo_test.py
+++ b/tests/camo_test.py
@@ -43,11 +43,6 @@ class CamoClientTest(unittest.TestCase):
         html = """<p><img src="https://fakecdn.org/images/hahafunny.jpg"></p>"""
         self.assertEqual(client.parse_html(html), html)
 
-    def test_ignores_data_uri(self):
-        client = CamoClient("https://fakecdn.org/", key="hello")
-        html = """<p><img src="data:image/png;base64,iVBOR0t8XDY0bb"></p>"""
-        self.assertEqual(client.parse_html(html), html)
-
     def test_unmarkedup_text(self):
         client = CamoClient("https://fakecdn.org/", key="hello")
         text = """butts"""


### PR DESCRIPTION
As part of quantopian/nbconvert-sanitize#15, I needed to expose _rewrite_url. It seemed to be better to combine img_url and _rewrite_url into .a single method, and use img_url in nbconvert-sanitize.