### PR TITLE
Upgrade to Python 3.5

### DIFF
--- a/camo.py
+++ b/camo.py
@@ -29,13 +29,13 @@ class CamoClient(object):
         doc = self._rewrite_image_urls(doc)
         # iterating over a node returns all the tags within that node
         # ..if there are none, return the original string
-        return ''.join(map(html.tostring, doc)) or string
+        return b''.join(map(html.tostring, doc)).decode() or string
 
 
 class Image(object):
     def __init__(self, url, key):
-        self.url = url
-        self.key = key
+        self.url = url.encode('utf-8')
+        self.key = key.encode('utf-8')
 
     @mproperty
     def path(self):
@@ -47,4 +47,4 @@ class Image(object):
 
     @mproperty
     def encoded_url(self):
-        return self.url.encode("hex")
+        return self.url.hex()

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,8 @@ setup(
         'Operating System :: OS Independent',
         'License :: OSI Approved :: MIT License',
         'Topic :: Software Development :: Libraries :: Python Modules',
-        'Topic :: Internet :: Proxy Servers'
+        'Topic :: Internet :: Proxy Servers',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python',
     ],
 )

--- a/tests/camo_test.py
+++ b/tests/camo_test.py
@@ -1,11 +1,16 @@
 import unittest
+
 from camo import CamoClient, Image
 
 
 class CamoImageTest(unittest.TestCase):
     def test_encodes_url(self):
         image = Image("http://example.net/images/hahafunny.jpg", key="hello")
-        self.assertEqual(image.path, '/735030fa488e1866b4302ac611c075d541a773e3/687474703a2f2f6578616d706c652e6e65742f696d616765732f6861686166756e6e792e6a7067')
+        self.assertEqual(
+            image.path,
+            '/735030fa488e1866b4302ac611c075d541a773e3/687474703a2f2f6578616d7'
+            '06c652e6e65742f696d616765732f6861686166756e6e792e6a7067',
+        )
 
 
 class CamoClientTest(unittest.TestCase):
@@ -13,34 +18,57 @@ class CamoClientTest(unittest.TestCase):
         client = CamoClient("https://fakecdn.org", key="hello")
         self.assertEqual(
             client.image_url("http://example.net/images/hahafunny.jpg"),
-            'https://fakecdn.org/735030fa488e1866b4302ac611c075d541a773e3/687474703a2f2f6578616d706c652e6e65742f696d616765732f6861686166756e6e792e6a7067'
+            'https://fakecdn.org/735030fa488e1866b4302ac611c075d541a773e3/6874'
+            '74703a2f2f6578616d706c652e6e65742f696d616765732f6861686166756e6e7'
+            '92e6a7067',
         )
 
     def test_trailing_slash(self):
         client = CamoClient("https://fakecdn.org/", key="hello")
         self.assertEqual(
             client.image_url("http://example.net/images/hahafunny.jpg"),
-            'https://fakecdn.org/735030fa488e1866b4302ac611c075d541a773e3/687474703a2f2f6578616d706c652e6e65742f696d616765732f6861686166756e6e792e6a7067'
+            'https://fakecdn.org/735030fa488e1866b4302ac611c075d541a773e3/6874'
+            '74703a2f2f6578616d706c652e6e65742f696d616765732f6861686166756e6e7'
+            '92e6a7067',
         )
 
     def test_parses_html(self):
         client = CamoClient("https://fakecdn.org/", key="hello")
-        html = """<img src="http://example.net/images/hahafunny.jpg" /><img src="https://otherexample/moreserious.png" />"""\
-               """<img src="//example.net/no_http.jpg" /><img src=" http://example.net/leading_space.jpg" />"""\
-               """<img src=http://example.net/mising_quotes.jpg /><img src="ftp://example.net/ftp_image.jpg" />"""\
-               """<img src="/images/hahafunny.jpg">"""
-        parsed = """<img src="https://fakecdn.org/735030fa488e1866b4302ac611c075d541a773e3/687474703a2f2f6578616d706c652e6e65742f696d616765732f6861686166756e6e792e6a7067">"""\
-                 """<img src="https://fakecdn.org/c81915f5756fad02cfae7d07e359624dae877667/68747470733a2f2f6f746865726578616d706c652f6d6f7265736572696f75732e706e67">"""\
-                 """<img src="https://fakecdn.org/1d5de168888358e62b7c2f850265c5bfb43e46c3/2f2f6578616d706c652e6e65742f6e6f5f687474702e6a7067">"""\
-                 """<img src="https://fakecdn.org/f4837f9cd17f391dd4c78e49f7b57934f6966f7c/20687474703a2f2f6578616d706c652e6e65742f6c656164696e675f73706163652e6a7067">"""\
-                 """<img src="https://fakecdn.org/d4ef06afe02debfdcbce1b1b078666e918732793/687474703a2f2f6578616d706c652e6e65742f6d6973696e675f71756f7465732e6a7067">"""\
-                 """<img src="https://fakecdn.org/46bb6a3963ac29bd9c1587f2f533dad926c82330/6674703a2f2f6578616d706c652e6e65742f6674705f696d6167652e6a7067">"""\
-                 """<img src="https://fakecdn.org/17c855d7008b1307d277d725cb045b0fc0e23ea7/2f696d616765732f6861686166756e6e792e6a7067">"""
+        html = (
+            '<img src="http://example.net/images/hahafunny.jpg" />'
+            '<img src="https://otherexample/moreserious.png" />'
+            '<img src="//example.net/no_http.jpg" />'
+            '<img src=" http://example.net/leading_space.jpg" />'
+            '<img src=http://example.net/mising_quotes.jpg />'
+            '<img src="ftp://example.net/ftp_image.jpg" />'
+            '<img src="/images/hahafunny.jpg">'
+        )
+        parsed = (
+            '<img src="https://fakecdn.org/735030fa488e1866b4302ac611c075d541a'
+            '773e3/687474703a2f2f6578616d706c652e6e65742f696d616765732f6861686'
+            '166756e6e792e6a7067">'
+            '<img src="https://fakecdn.org/c81915f5756fad02cfae7d07e359624dae8'
+            '77667/68747470733a2f2f6f746865726578616d706c652f6d6f7265736572696'
+            'f75732e706e67">'
+            '<img src="https://fakecdn.org/1d5de168888358e62b7c2f850265c5bfb43'
+            'e46c3/2f2f6578616d706c652e6e65742f6e6f5f687474702e6a7067">'
+            '<img src="https://fakecdn.org/f4837f9cd17f391dd4c78e49f7b57934f69'
+            '66f7c/20687474703a2f2f6578616d706c652e6e65742f6c656164696e675f737'
+            '06163652e6a7067">'
+            '<img src="https://fakecdn.org/d4ef06afe02debfdcbce1b1b078666e9187'
+            '32793/687474703a2f2f6578616d706c652e6e65742f6d6973696e675f71756f7'
+            '465732e6a7067">'
+            '<img src="https://fakecdn.org/46bb6a3963ac29bd9c1587f2f533dad926c'
+            '82330/6674703a2f2f6578616d706c652e6e65742f6674705f696d6167652e6a7'
+            '067">'
+            '<img src="https://fakecdn.org/17c855d7008b1307d277d725cb045b0fc0e'
+            '23ea7/2f696d616765732f6861686166756e6e792e6a7067">'
+        )
         self.assertEqual(client.parse_html(html), parsed)
 
     def test_ignores_already_hosted(self):
         client = CamoClient("https://fakecdn.org/", key="hello")
-        html = """<p><img src="https://fakecdn.org/images/hahafunny.jpg"></p>"""
+        html = '<p><img src="https://fakecdn.org/images/hahafunny.jpg"></p>'
         self.assertEqual(client.parse_html(html), html)
 
     def test_unmarkedup_text(self):


### PR DESCRIPTION
Values that were previously assumed to be bytes objects (strings in Python 2) now need to be made explicitly so.